### PR TITLE
Add unicode support to `\pdfpcnote` for LuaTeX

### DIFF
--- a/pdfpc/README.md
+++ b/pdfpc/README.md
@@ -12,6 +12,10 @@ console (pdfpc) program.
 [`iftex`](https://ctan.org/pkg/iftex),
 [`hyperxmp`](https://ctan.org/pkg/hyperxmp)
 
+When using LuaTeX, it additionally depends on these packages:
+[`stringenc`](https://ctan.org/pkg/stringenc)
+[`pdftexcmds`](https://ctan.org/pkg/pdftexcmds)
+
 ## Usage
 
 It's best to read the [`pdfpc`](https://github.com/pdfpc/pdfpc) documentation

--- a/pdfpc/README.md
+++ b/pdfpc/README.md
@@ -13,7 +13,7 @@ console (pdfpc) program.
 [`hyperxmp`](https://ctan.org/pkg/hyperxmp)
 
 When using LuaTeX, it additionally depends on these packages:
-[`stringenc`](https://ctan.org/pkg/stringenc)
+[`stringenc`](https://ctan.org/pkg/stringenc),
 [`pdftexcmds`](https://ctan.org/pkg/pdftexcmds)
 
 ## Usage

--- a/pdfpc/pdfpc.sty
+++ b/pdfpc/pdfpc.sty
@@ -38,6 +38,10 @@
 \RequirePackage{xstring}
 \RequirePackage{iftex}
 \RequirePackage{hyperxmp}
+\ifLuaTeX
+  \RequirePackage{stringenc}
+  \RequirePackage{pdftexcmds}
+\fi
 %
 \SetupKeyvalOptions{
   family=PDFPC,
@@ -167,18 +171,32 @@ ______</rdf:Description>^^J%
   \else%
     \ifLuaTeX%
       \protected\def\pdfannot {\pdfextension annot }%
-    \fi%
-    \newcommand{\pdfpcnote}[1]{%
-      {%
-        \edef\\{\string\n}%
-        \pdfannot width 0pt height 0pt depth 0pt {%
-           /Subtype /Text%
-           /Contents (#1)%
-           /F 6%
+      \newcommand{\pdfpcnote}[1]{%
+        \edef\tmp@a{\pdf@escapehexnative{#1}}
+        \expandafter\SE@ConvertFrom\expandafter\tmp@a\expandafter{\tmp@a}{utf8}
+        {%
+          \edef\\{\string\n}%
+          \pdfannot width 0pt height 0pt depth 0pt {%
+             /Subtype /Text%
+             /Contents <FEFF\tmp@a>%
+             /F 6%
+          }%
         }%
+        \relax%
       }%
-      \relax%
-    }%
+    \else%
+      \newcommand{\pdfpcnote}[1]{%
+        {%
+          \edef\\{\string\n}%
+          \pdfannot width 0pt height 0pt depth 0pt {%
+             /Subtype /Text%
+             /Contents (#1)%
+             /F 6%
+          }%
+        }%
+        \relax%
+      }%
+    \fi%
   \fi%
 \fi%
 %


### PR DESCRIPTION
It is highly counterintuitive that with the LuaTeX engine, which is usually perceived as having native unicode support, the `\pdfpcnote` command supports only ascii characters. At the cost of two additional dependency packages, this PR fixes that issue, offering full unicode support instead.

The example
```latex
\documentclass{beamer}
\usepackage{pdfpc}
\begin{document}
\begin{frame}
	\pdfpcnote{ä β 你好 😂}
\end{frame}
\end{document}
```
then shows up as:
![A pdfpc window with the note showing up as in the code](https://user-images.githubusercontent.com/11999912/183327585-7c7cb2ac-9266-438d-bfc1-300f3e5d6fa9.png)

This fixes parts of #5.