### PR TITLE
LuaTeX linebreaks

### DIFF
--- a/pdfpc/README.md
+++ b/pdfpc/README.md
@@ -10,10 +10,10 @@ console (pdfpc) program.
 [`kvoptions`](https://ctan.org/pkg/kvoptions),
 [`xstring`](https://ctan.org/pkg/xstring),
 [`iftex`](https://ctan.org/pkg/iftex),
-[`hyperxmp`](https://ctan.org/pkg/hyperxmp)
+[`hyperxmp`](https://ctan.org/pkg/hyperxmp),
+[`stringenc`](https://ctan.org/pkg/stringenc)
 
-When using LuaTeX, it additionally depends on these packages:
-[`stringenc`](https://ctan.org/pkg/stringenc),
+When using LuaTeX, it additionally depends on these package
 [`pdftexcmds`](https://ctan.org/pkg/pdftexcmds)
 
 ## Usage

--- a/pdfpc/pdfpc-doc.tex
+++ b/pdfpc/pdfpc-doc.tex
@@ -68,8 +68,9 @@ GitHub}\footnote{\url{https://pdfpc.github.io/}}.
 
 It depends on the following packages:
 
-\begin{multicols}{4}\sffamily\centering
-kvoptions \\ xstring \\ iftex \\ hyperxmp
+\begin{multicols}{3}\sffamily\centering
+kvoptions \\ xstring \\ iftex \\ hyperxmp \\ stringenc \\
+pdftexcmds\footnote{Only when using Lua\LaTeX}
 \end{multicols}
 
 \section*{License}

--- a/pdfpc/pdfpc.sty
+++ b/pdfpc/pdfpc.sty
@@ -169,33 +169,33 @@ ______</rdf:Description>^^J%
       \relax%
     }%
   \else%
-    \def\insert@linebreaks@in@hex#1#2#3#4#5\hex@terminator{%
+    \def\pdfpc@hexnewlines#1#2#3#4#5\pdfpc@@end{%
       \if\relax\detokenize{#5}\relax
         #1#2#3#4%
       \else
         \ifnum"#1#2>"D7
           \ifnum"#1#2<"E0
-            #1#2#3#4\insert@linebreaks@in@hex@nonbmp#5\hex@terminator
+            #1#2#3#4\pdfpc@hexnewlines@nonbmp#5\pdfpc@@end
           \else
-            #1#2#3#4\insert@linebreaks@in@hex#5\hex@terminator
+            #1#2#3#4\pdfpc@hexnewlines#5\pdfpc@@end
           \fi
         \else
           \ifnum"#1#2#3#4="005C
-            \insert@linebreaks@in@hex@afterbs#5\hex@terminator
+            \pdfpc@hexnewlines@afterbs#5\pdfpc@@end
           \else
-            #1#2#3#4\insert@linebreaks@in@hex#5\hex@terminator
+            #1#2#3#4\pdfpc@hexnewlines#5\pdfpc@@end
           \fi
         \fi
       \fi
     }
-    \def\insert@linebreaks@in@hex@nonbmp#1#2#3#4#5\hex@terminator{%
+    \def\pdfpc@hexnewlines@nonbmp#1#2#3#4#5\pdfpc@@end{%
       \if\relax\detokenize{#5}\relax
         #1#2#3#4%
       \else
-        #1#2#3#4\insert@linebreaks@in@hex#5\hex@terminator
+        #1#2#3#4\pdfpc@hexnewlines#5\pdfpc@@end
       \fi
     }
-    \def\insert@linebreaks@in@hex@afterbs#1#2#3#4#5\hex@terminator{%
+    \def\pdfpc@hexnewlines@afterbs#1#2#3#4#5\pdfpc@@end{%
       \if\relax\detokenize{#5}\relax
         \ifnum"#1#2#3#4="005C
           000A%
@@ -205,15 +205,15 @@ ______</rdf:Description>^^J%
       \else
         \ifnum"#1#2>"D7
           \ifnum"#1#2<"E0
-            #1#2#3#4\insert@linebreaks@in@hex@nonbmp#5\hex@terminator
+            #1#2#3#4\pdfpc@hexnewlines@nonbmp#5\pdfpc@@end
           \else
-            #1#2#3#4\insert@linebreaks@in@hex#5\hex@terminator
+            #1#2#3#4\pdfpc@hexnewlines#5\pdfpc@@end
           \fi
         \else
           \ifnum"#1#2#3#4="005C
-            000A\insert@linebreaks@in@hex#5\hex@terminator
+            000A\pdfpc@hexnewlines#5\pdfpc@@end
           \else
-            005C#1#2#3#4\insert@linebreaks@in@hex#5\hex@terminator
+            005C#1#2#3#4\pdfpc@hexnewlines#5\pdfpc@@end
           \fi
         \fi
       \fi
@@ -227,7 +227,7 @@ ______</rdf:Description>^^J%
         {%
           \pdfannot width 0pt height 0pt depth 0pt {%
              /Subtype /Text%
-             /Contents <\expandafter\insert@linebreaks@in@hex\tmp@a\hex@terminator>%
+             /Contents <\expandafter\pdfpc@hexnewlines\tmp@a\pdfpc@@end>%
              /F 6%
           }%
         }%

--- a/pdfpc/pdfpc.sty
+++ b/pdfpc/pdfpc.sty
@@ -38,8 +38,8 @@
 \RequirePackage{xstring}
 \RequirePackage{iftex}
 \RequirePackage{hyperxmp}
+\RequirePackage{stringenc}
 \ifLuaTeX
-  \RequirePackage{stringenc}
   \RequirePackage{pdftexcmds}
 \fi
 %

--- a/pdfpc/pdfpc.sty
+++ b/pdfpc/pdfpc.sty
@@ -169,16 +169,65 @@ ______</rdf:Description>^^J%
       \relax%
     }%
   \else%
+    \def\insert@linebreaks@in@hex#1#2#3#4#5\hex@terminator{%
+      \if\relax\detokenize{#5}\relax
+        #1#2#3#4%
+      \else
+        \ifnum"#1#2>"D7
+          \ifnum"#1#2<"E0
+            #1#2#3#4\insert@linebreaks@in@hex@nonbmp#5\hex@terminator
+          \else
+            #1#2#3#4\insert@linebreaks@in@hex#5\hex@terminator
+          \fi
+        \else
+          \ifnum"#1#2#3#4="005C
+            \insert@linebreaks@in@hex@afterbs#5\hex@terminator
+          \else
+            #1#2#3#4\insert@linebreaks@in@hex#5\hex@terminator
+          \fi
+        \fi
+      \fi
+    }
+    \def\insert@linebreaks@in@hex@nonbmp#1#2#3#4#5\hex@terminator{%
+      \if\relax\detokenize{#5}\relax
+        #1#2#3#4%
+      \else
+        #1#2#3#4\insert@linebreaks@in@hex#5\hex@terminator
+      \fi
+    }
+    \def\insert@linebreaks@in@hex@afterbs#1#2#3#4#5\hex@terminator{%
+      \if\relax\detokenize{#5}\relax
+        \ifnum"#1#2#3#4="005C
+          000A%
+        \else
+          005C#1#2#3#4%
+        \fi
+      \else
+        \ifnum"#1#2>"D7
+          \ifnum"#1#2<"E0
+            #1#2#3#4\insert@linebreaks@in@hex@nonbmp#5\hex@terminator
+          \else
+            #1#2#3#4\insert@linebreaks@in@hex#5\hex@terminator
+          \fi
+        \else
+          \ifnum"#1#2#3#4="005C
+            000A\insert@linebreaks@in@hex#5\hex@terminator
+          \else
+            005C#1#2#3#4\insert@linebreaks@in@hex#5\hex@terminator
+          \fi
+        \fi
+      \fi
+    }
     \ifLuaTeX%
       \protected\def\pdfannot {\pdfextension annot }%
       \newcommand{\pdfpcnote}[1]{%
         \edef\tmp@a{\pdf@escapehexnative{#1}}
         \expandafter\SE@ConvertFrom\expandafter\tmp@a\expandafter{\tmp@a}{utf8}
+        \edef\tmp@a{FEFF\tmp@a}
         {%
-          \edef\\{\string\n}%
           \pdfannot width 0pt height 0pt depth 0pt {%
              /Subtype /Text%
-             /Contents <FEFF\tmp@a>%
+             /Contents <\expandafter\insert@linebreaks@in@hex\tmp@a\hex@terminator>%
              /F 6%
           }%
         }%


### PR DESCRIPTION
When I implemented the unicode support for LuaTeX, I just plain forgot to test for the linebreaking behaviour in the notes. Consequently, there is no linebreaking currently and `\\` does not work as advertised. This PR should not be merged but after some discussion either thrown away or cherry-picked, squashed and rebased.

Less relevant changes:
* Since `stringenc` is currently implied by `hyperxmp` anyway, I moved it out of the LuaTeX conditional.
* I updated the required packages in the documentation (but https://github.com/pdfpc/latex-pdfpc/commit/b754dd7ae145ec736079c94a66311482190bb0fd did that, too).

Relevant changes:
* This monstrosity of a code runs through the hex expansion of the UTF-16BE encoding and looks for double backslashes which it then turns into line feeds.

Caveats:
* I tried for a bit to find a cleaner solution, but as I did not find any and I felt responsible for screwing that up, I decided to sit down and try for the ugly (but hopefully working) one.
* I have definitely not tested this code thoroughly so far. I do not expect it to be bug-free as-is.

Going forth:
* Do you want to go for the ugly solution as presented here?
* If so, I'm planning to create some sort of test-suite (though I'm not quite sure how yet).
* Obviously, I'm not the best judge whether I've covered all the (edge)cases, so if people (including non-maintainers) have the time, I'd definitely welcome ≥4 eyes of scrutiny so I'll lose less sleep over this. ^^