### PR TITLE
makes the overriden \note command overlay-aware

### DIFF
--- a/pdfpc/pdfpc.sty
+++ b/pdfpc/pdfpc.sty
@@ -81,11 +81,11 @@
 \fi
 %
 \ifPDFPC@overridenote
-  \renewcommand{\note}[2][]{%
-    \IfStrEq{#1}{item}%
+  \renewcommand<>{\note}[2][]{%
+    \only#3{\IfStrEq{#1}{item}%
       % Imitate a bullet
       {\pdfpcnote{* #2}}%
-      {\pdfpcnote{#2}}%
+      {\pdfpcnote{#2}}}%
   }%
 \fi
 %


### PR DESCRIPTION
The original \note command is overlay aware, so it is possible to show notes only on some subslides. This patch makes the overriden command keep this feature.

fixes: https://github.com/pdfpc/pdfpc/issues/653