### PR TITLE
Make \pdfpcnote command overlay-aware

### DIFF
--- a/pdfpc/pdfpc-doc.tex
+++ b/pdfpc/pdfpc-doc.tex
@@ -122,11 +122,13 @@ like \cmd{\pdfpcsetup\{\param{option1=value1}[,~\ldots]\}}.
 The meaning and possible values of most of these options are documented in
 \textit{pdfpcrc(5)} man page of the pdfpc program. The rest are explained below.
 
-To add a note to a slide, use \cmd{\pdfpcnote\{Text of a note\}}. A line break
-in the body of the note can be inserted with \cmd{\\}. The notes are rendered
-according to the Markdown syntax by default. If you prefer the plain text format
-(which was the case with \texttt{pdfpc}-4.4 and below), use the
-\texttt{disablemarkdown} option.
+To add a note to a slide, use \cmd{\pdfpcnote\{Text of a note\}}, which also
+supports Beamer's overlay specifications\footnote{See sections 3.10 and 9.2 of
+the \texttt{beamer} package documentation.}. A line break in the body of the
+note can be inserted with \cmd{\\}. The notes are rendered according to the
+Markdown syntax by default. If you prefer the plain text format (which was the
+case with \texttt{pdfpc}-4.4 and below), use the \texttt{disablemarkdown}
+option.
 
 The pdfpc package can be used standalone or together with beamer. In
 the later case, it may be desirable to continue using the \cmd{\note}

--- a/pdfpc/pdfpc.sty
+++ b/pdfpc/pdfpc.sty
@@ -82,10 +82,10 @@
 %
 \ifPDFPC@overridenote
   \renewcommand<>{\note}[2][]{%
-    \only#3{\IfStrEq{#1}{item}%
+    \IfStrEq{#1}{item}%
       % Imitate a bullet
-      {\pdfpcnote{* #2}}%
-      {\pdfpcnote{#2}}}%
+      {\pdfpcnote#3{* #2}}%
+      {\pdfpcnote#3{#2}}%
   }%
 \fi
 %

--- a/pdfpc/pdfpc.sty
+++ b/pdfpc/pdfpc.sty
@@ -152,11 +152,11 @@ ______</rdf:Description>^^J%
 %
 % Note command
 \ifPDFPC@hidenotes%
-  \newcommand{\pdfpcnote}[1]{}%
+  \newcommand<>{\pdfpcnote}[1]{}%
 \else%
   \ifXeTeX%
-    \newcommand{\pdfpcnote}[1]{%
-      {%
+    \newcommand<>{\pdfpcnote}[1]{%
+      \only#2{%
         \edef\\{\string\n}%
         \special{pdf: ann width 0pt height 0pt depth 0pt%
            <<%
@@ -171,22 +171,24 @@ ______</rdf:Description>^^J%
   \else%
     \ifLuaTeX%
       \protected\def\pdfannot {\pdfextension annot }%
-      \newcommand{\pdfpcnote}[1]{%
-        \edef\tmp@a{\pdf@escapehexnative{#1}}
-        \expandafter\SE@ConvertFrom\expandafter\tmp@a\expandafter{\tmp@a}{utf8}
-        {%
-          \edef\\{\string\n}%
-          \pdfannot width 0pt height 0pt depth 0pt {%
-             /Subtype /Text%
-             /Contents <FEFF\tmp@a>%
-             /F 6%
+      \newcommand<>{\pdfpcnote}[1]{%
+        \only#2{%
+          \edef\tmp@a{\pdf@escapehexnative{#1}}
+          \expandafter\SE@ConvertFrom\expandafter\tmp@a\expandafter{\tmp@a}{utf8}
+          {%
+            \edef\\{\string\n}%
+            \pdfannot width 0pt height 0pt depth 0pt {%
+               /Subtype /Text%
+               /Contents <FEFF\tmp@a>%
+               /F 6%
+            }%
           }%
         }%
         \relax%
       }%
     \else%
-      \newcommand{\pdfpcnote}[1]{%
-        {%
+      \newcommand<>{\pdfpcnote}[1]{%
+        \only#2{%
           \edef\\{\string\n}%
           \pdfannot width 0pt height 0pt depth 0pt {%
              /Subtype /Text%


### PR DESCRIPTION
Adds support for Beamer overlay specifications to the provided `\pdfpcnote` command.

Resolves #9
