### PR TITLE
Clean up and elaborate documentation

### DIFF
--- a/pdfpc/README.md
+++ b/pdfpc/README.md
@@ -46,7 +46,7 @@ The following is a simple LaTeX document demonstrating a few example features:
 
 % The usual Beamer document setup
 \title{\texttt{pdfpc} Example Presentation}
-\author{LRitzdorf}
+\author{\texttt{pdfpc} Contributors}
 \institute{GitHub}
 \date{\today}
 

--- a/pdfpc/README.md
+++ b/pdfpc/README.md
@@ -1,12 +1,14 @@
 # pdfpc
 
-This packages allows to define additional meta data within
-the PDF file which can be interpreted by the pdf presenter
-console (pdfpc) program.
+This LaTeX package provides a convenient way to specify notes and to define
+certain meta properties of the presentation when used with [PDF Presenter
+Console (`pdfpc`)](https://pdfpc.github.io), a GPLv3+ licensed multi-monitor PDF
+presentation viewer application available on GitHub.
+
 
 ## Dependencies
 
-`pdfpc` depends on these packages:
+The `pdfpc` package depends on these other packages:
 [`kvoptions`](https://ctan.org/pkg/kvoptions),
 [`xstring`](https://ctan.org/pkg/xstring),
 [`iftex`](https://ctan.org/pkg/iftex),
@@ -16,8 +18,56 @@ When using LuaTeX, it additionally depends on these packages:
 [`stringenc`](https://ctan.org/pkg/stringenc),
 [`pdftexcmds`](https://ctan.org/pkg/pdftexcmds)
 
+
 ## Usage
 
-It's best to read the [`pdfpc`](https://github.com/pdfpc/pdfpc) documentation
-for `pdfpc` integration.
+The [PDF Presenter Console](https://pdfpc.github.io) program accepts a variety
+of configuration options when started from the command line. (See the *pdfpc(1)*
+manual page for details.)
 
+This package allows certain details, such as presentation duration, default
+slide transitions, and speaker notes, to be specified within the metadata of the
+PDF itself, instead of via the command line. These settings are parsed by the
+PDF Presenter Console when the presentation is loaded.
+
+These parameters can be specified as package options, and/or via the `\pdfpcsetup` command.
+
+The following is a simple LaTeX document demonstrating a few example features:
+
+```latex
+\documentclass{beamer}
+\usepackage[overridenote]{pdfpc}
+% "overridenote" must be specified as a package option
+\pdfpcsetup{
+    % Other settings can be package options, or can go here
+    duration=5,
+    lastminutes=2,
+}
+
+% The usual Beamer document setup
+\title{\texttt{pdfpc} Example Presentation}
+\author{LRitzdorf}
+\institute{GitHub}
+\date{\today}
+
+\begin{document}
+\maketitle
+
+\begin{frame}
+    Hello PDFPC World!
+    % Because of "overridenote", this uses the pdfpc note command
+    \note{This speaker note will be shown by `pdfpc`, but hidden for the audience.}
+    \pause
+    Notice that the timer starts counting down from 5 minutes, just as we specified in the preamble!
+\end{frame}
+
+\end{document}
+```
+
+
+## Documentation
+
+Complete
+[documentation](http://mirrors.ctan.org/macros/latex/contrib/pdfpc/pdfpc-doc.pdf)
+for the current version of `pdfpc` is availble on [its CTAN
+page](https://ctan.org/pkg/pdfpc).

--- a/pdfpc/README.md
+++ b/pdfpc/README.md
@@ -30,7 +30,7 @@ slide transitions, and speaker notes, to be specified within the metadata of the
 PDF itself, instead of via the command line. These settings are parsed by the
 PDF Presenter Console when the presentation is loaded.
 
-These parameters can be specified as package options, and/or via the `\pdfpcsetup` command.
+These parameters can be specified as package options, or via the `\pdfpcsetup` command.
 
 The following is a simple LaTeX document demonstrating a few example features:
 

--- a/pdfpc/pdfpc-doc.tex
+++ b/pdfpc/pdfpc-doc.tex
@@ -114,18 +114,18 @@ The following options may be given as comma-separated list:
 \centering
 \begin{tabular}{ l l }
     \hline
-    Package option & Equivalent \texttt{pdfpc} feature \\
+    Package option & Equivalent \texttt{pdfpc} flag \\
     \hline
-    \texttt{duration}          & \texttt{--duration} \\
-    \texttt{starttime}         & \texttt{--start-time} \\
-    \texttt{endtime}           & \texttt{--end-time} \\
-    \texttt{lastminutes}       & \texttt{--last-minutes} \\
-    \texttt{enduserslide}      & Ctrl+e keybind \\
-    \texttt{notesposition}     & \texttt{--notes} \\
-    \texttt{disablemarkdown}   & \texttt{--note-format} \\
-    \texttt{hidenotes}         & \\
-    \texttt{overridenote}      & \\
-    \texttt{defaulttransition} & \texttt{--page-transition} (\texttt{pdfpc} v4.5 or later) \\
+    \texttt{duration=\textit{value}}          & \texttt{--duration=\textit{value}} \\
+    \texttt{starttime=\textit{value}}         & \texttt{--start-time=\textit{value}} \\
+    \texttt{endtime=\textit{value}}           & \texttt{--end-time=\textit{value}} \\
+    \texttt{lastminutes=\textit{value}}       & \texttt{--last-minutes=\textit{value}} \\
+    \texttt{enduserslide=\textit{value}}      & \\
+    \texttt{notesposition=\textit{value}}     & \texttt{--notes=\textit{value}} \\
+    \texttt{disablemarkdown}                  & \texttt{--note-format=plain} \\
+    \texttt{hidenotes}                        & \\
+    \texttt{overridenote}                     & \\
+    \texttt{defaulttransition=\textit{value}} & \texttt{--page-transition=\textit{value}} \\
     \hline
 \end{tabular}
 \end{table}
@@ -151,6 +151,9 @@ To override the autodetection, use the \texttt{notesposition} option, accepting 
 
 When sharing slides, one may want to omit the (potentially private) notes, by using the \texttt{hidenotes} option.
 Enabling it will disable notes, including Beamer notes if \texttt{overridenote} was specified.
+
+Finally, be aware that some features are unsupported by old versions of the \texttt{pdfpc} console.
+In particular, the \texttt{defaulttransition} option requires version 4.5 or later.
 
 \StopEventually{%
     \clearpage

--- a/pdfpc/pdfpc-doc.tex
+++ b/pdfpc/pdfpc-doc.tex
@@ -108,23 +108,31 @@ This work consists of the following files:
 \section*{Loading \sty{pdfpc}}
 
 Load \sty{pdfpc} by adding \cmd{\usepackage[\param{options}]\{pdfpc\}} to your preamble.
-
 The following options may be given as comma-separated list:
 
-\begin{itemize}
-    \item \texttt{duration}
-    \item \texttt{starttime}
-    \item \texttt{endtime}
-    \item \texttt{enduserslide}
-    \item \texttt{lastminutes}
-    \item \texttt{hidenotes}
-    \item \texttt{notesposition}
-    \item \texttt{overridenote}
-    \item \texttt{disablemarkdown}
-    \item \texttt{defaulttransition} (needs pdfpc v4.5 or higher)
-\end{itemize}
+\begin{table}[h]
+\centering
+\begin{tabular}{ l l }
+    \hline
+    Package option & Equivalent \texttt{pdfpc} feature \\
+    \hline
+    \texttt{duration}          & \texttt{--duration} \\
+    \texttt{starttime}         & \texttt{--start-time} \\
+    \texttt{endtime}           & \texttt{--end-time} \\
+    \texttt{lastminutes}       & \texttt{--last-minutes} \\
+    \texttt{enduserslide}      & Ctrl+e keybind \\
+    \texttt{notesposition}     & \texttt{--notes} \\
+    \texttt{disablemarkdown}   & \texttt{--note-format} \\
+    \texttt{hidenotes}         & \\
+    \texttt{overridenote}      & \\
+    \texttt{defaulttransition} & \texttt{--page-transition} (\texttt{pdfpc} v4.5 or later) \\
+    \hline
+\end{tabular}
+\end{table}
 
-Alternatively, the options can be set using the \cmd{\pdfpcsetup} command like \cmd{\pdfpcsetup\{\param{option1=value1}[,~\ldots]\}} (except \texttt{overridenote}, which only works as a proper package option).
+Options should be given as a comma-separated list.
+All options, aside from \texttt{overridenote}, can alternatively be set via a command of the form \cmd{\pdfpcsetup\{\param{option1=value1}[,~\ldots]\}}.
+
 The meaning and possible values of most of these options are documented in the \textit{pdfpc(1)} man page, provided by the \texttt{pdfpc} program.
 The rest are explained below.
 

--- a/pdfpc/pdfpc-doc.tex
+++ b/pdfpc/pdfpc-doc.tex
@@ -37,6 +37,8 @@
 
 \usepackage{hyperref}
 
+\usepackage{enumitem}
+
 \newcommand*{\sty}[1]{\textsf{#1}}
 \def\param#1%
 {\textit{\rmfamily\mdseries\ensuremath{\langle}#1\ensuremath{\rangle}}}
@@ -49,43 +51,47 @@
 
 \hypersetup{pdftitle={The pdfpc package}, pdfauthor={Evgeny Stambulchik}}
 
+\setlist{noitemsep}
+
 \begin{document}
 \maketitle
 \thispagestyle{empty}
 
 \begin{abstract}
-This package provides a convenient way to specify notes and to define certain
-meta properties of the presentation when used with
-\href{https://pdfpc.github.io/}{PDF Presenter Console (\texttt{pdfpc}), a
-GPLv3+ licensed multi-monitor PDF presentation viewer application available on
-GitHub}\footnote{\url{https://pdfpc.github.io/}}.
+This package provides a convenient way to specify notes and to define certain meta properties of the presentation when used with \href{https://pdfpc.github.io}{PDF Presenter Console (\texttt{pdfpc})}, a GPLv3+ licensed multi-monitor PDF presentation viewer application available on GitHub\footnote{\url{https://pdfpc.github.io}}.
 \end{abstract}
 
+
 \clearpage
+
 \section*{Dependencies and other requirements}
 
 \sty{pdfpc} requires the use of \LaTeXe.
 
 It depends on the following packages:
 
-\begin{multicols}{4}\sffamily\centering
-kvoptions \\ xstring \\ iftex \\ hyperxmp
-\end{multicols}
+\begin{itemize}
+    \sffamily
+    \item kvoptions
+    \item xstring
+    \item iftex
+    \item hyperxmp
+\end{itemize}
 
 When using LuaTeX, it additionally depends on these packages:
 
-\begin{multicols}{2}\sffamily\centering
-stringenc \\ pdftexcmds
-\end{multicols}
+\begin{itemize}
+    \sffamily
+    \item stringenc
+    \item pdftexcmds
+\end{itemize}
+
 
 \section*{License}
 
 \textcopyright\ 2020--2022 Evgeny Stambulchik
 
-This program is free software; you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 3 of the License, or
-(at your option) any later version.
+This program is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation; either version 3 of the License, or (at your option) any later version.
 
 This work consists of the following files:
 
@@ -95,55 +101,48 @@ This work consists of the following files:
     \item ``pdfpc-doc.pdf'' \emph{(compiled)}
 \end{itemize}
 
+
 \clearpage
 
 \part{The documentation}
 \section*{Loading \sty{pdfpc}}
 
-Load \sty{pdfpc} by adding \cmd{\usepackage[\param{options}]\{pdfpc\}} to your
-preamble.
+Load \sty{pdfpc} by adding \cmd{\usepackage[\param{options}]\{pdfpc\}} to your preamble.
 
 The following options may be given as comma-separated list:
 
 \begin{itemize}
-\item \texttt{duration}
-\item \texttt{starttime}
-\item \texttt{endtime}
-\item \texttt{enduserslide}
-\item \texttt{lastminutes}
-\item \texttt{hidenotes}
-\item \texttt{overridenote}
-\item \texttt{disablemarkdown}
-\item \texttt{defaulttransition} (needs pdfpc v4.5 or higher)
+    \item \texttt{duration}
+    \item \texttt{starttime}
+    \item \texttt{endtime}
+    \item \texttt{enduserslide}
+    \item \texttt{lastminutes}
+    \item \texttt{hidenotes}
+    \item \texttt{notesposition}
+    \item \texttt{overridenote}
+    \item \texttt{disablemarkdown}
+    \item \texttt{defaulttransition} (needs pdfpc v4.5 or higher)
 \end{itemize}
 
-Alternatively, the options can be set using the \cmd{\pdfpcsetup} command
-like \cmd{\pdfpcsetup\{\param{option1=value1}[,~\ldots]\}}.
-The meaning and possible values of most of these options are documented in
-\textit{pdfpcrc(5)} man page of the pdfpc program. The rest are explained below.
+Alternatively, the options can be set using the \cmd{\pdfpcsetup} command like \cmd{\pdfpcsetup\{\param{option1=value1}[,~\ldots]\}}.
+The meaning and possible values of most of these options are documented in the \textit{pdfpc(1)} man page, provided by the \texttt{pdfpc} program.
+The rest are explained below.
 
-To add a note to a slide, use \cmd{\pdfpcnote\{Text of a note\}}, which also
-supports Beamer's overlay specifications\footnote{See sections 3.10 and 9.2 of
-the \texttt{beamer} package documentation.}. A line break in the body of the
-note can be inserted with \cmd{\\}. The notes are rendered according to the
-Markdown syntax by default. If you prefer the plain text format (which was the
-case with \texttt{pdfpc}-4.4 and below), use the \texttt{disablemarkdown}
-option.
+To add a note to a slide, use \cmd{\pdfpcnote\{Text of a note\}}, which also supports Beamer's overlay specifications\footnote{See sections 3.10 and 9.2 of the \texttt{beamer} package documentation.}.
+A line break in the body of the note can be inserted with \cmd{\\}.
+The notes are rendered according to the Markdown syntax by default.
+If you prefer the plain text format (which was the case with \texttt{pdfpc}-4.4 and below), use the \texttt{disablemarkdown} option.
 
-The pdfpc package can be used standalone or together with beamer. In
-the later case, it may be desirable to continue using the \cmd{\note}
-command. To this end, the \texttt{overridenote} option should be provided.
-Please note though, that this will work only in simple cases.
+The pdfpc package can be used standalone or together with Beamer.
+In the later case, it may be desirable to continue using the \cmd{\note} command.
+To this end, the \texttt{overridenote} option should be provided.
+Note, however, that this will work only in simple cases.
 
-If you prefer using full-featured beamer notes rendered alongside the
-presentation (\cmd{\setbeameroption\{show notes on second screen\}}), the pdfpc
-package will autodetect it, so using the \texttt{--notes} command-line option is
-unnecessary. To override the autodetection, use the \texttt{notesposition}
-option, accepting the same values (right/left/top/bottom/none).
+If you prefer full-featured Beamer notes rendered alongside the presentation (as with \cmd{\setbeameroption\{show notes on second screen\}}), the pdfpc package will autodetect this, so using the \texttt{--notes} command-line option is unnecessary.
+To override the autodetection, use the \texttt{notesposition} option, accepting the same values (right/left/top/bottom/none) that Beamer natively supports.
 
-When sharing slides, one may want to omit the (private) notes, by using the
-\texttt{hidenotes} option. Enabling it together with \texttt{overridenote} will
-disable the beamer notes as well.
+When sharing slides, one may want to omit the (potentially private) notes, by using the \texttt{hidenotes} option.
+Enabling it will disable notes, including Beamer notes if \texttt{overridenote} was specified.
 
 \StopEventually{%
     \clearpage

--- a/pdfpc/pdfpc-doc.tex
+++ b/pdfpc/pdfpc-doc.tex
@@ -124,7 +124,7 @@ The following options may be given as comma-separated list:
     \item \texttt{defaulttransition} (needs pdfpc v4.5 or higher)
 \end{itemize}
 
-Alternatively, the options can be set using the \cmd{\pdfpcsetup} command like \cmd{\pdfpcsetup\{\param{option1=value1}[,~\ldots]\}}.
+Alternatively, the options can be set using the \cmd{\pdfpcsetup} command like \cmd{\pdfpcsetup\{\param{option1=value1}[,~\ldots]\}} (except \texttt{overridenote}, which only works as a proper package option).
 The meaning and possible values of most of these options are documented in the \textit{pdfpc(1)} man page, provided by the \texttt{pdfpc} program.
 The rest are explained below.
 


### PR DESCRIPTION
This PR includes some general documentation cleanup, and significantly expands documentation in the README.

One notable change to the package documentation LaTeX source is the re-wrapping of lines. Line breaks now occur at the end of every sentence, instead of at 80 characters.

This line-break policy is simply a matter of personal preference, and is by no means integral to this PR. However, it does make future commits and diffs significantly cleaner, since a change to one sentence equals a one-line diff.

Closes #4
Closes #10

